### PR TITLE
Correct filter while posting empty values

### DIFF
--- a/Products/PloneBooking/content/BookingCenter.py
+++ b/Products/PloneBooking/content/BookingCenter.py
@@ -621,8 +621,11 @@ class BookingCenter(ATFolder):
         query_args['portal_type'] = 'BookableObject'
         bookable_states = center_obj.getBookableObjectStates()
         query_args['review_state'] = bookable_states
+
         # Update query args
         if kwargs:
+            # Clean-up kwargs from empty values
+            kwargs = dict([(k, v) for k, v in kwargs.iteritems() if v])
             query_args.update(kwargs)
 
         return ctool.searchResults(**query_args)

--- a/Products/PloneBooking/skins/plonebooking_javascripts/plonebooking.js
+++ b/Products/PloneBooking/skins/plonebooking_javascripts/plonebooking.js
@@ -973,11 +973,16 @@ Booking.canRefresh = function() {
 
     var node = Booking.form.bcategory
 
-    if (node == 'select') {
-        var bcategory = node.options[node.selectedIndex].value;
-          var bcategoryRequired = node.parentNode.getElementsByTagName('span').length;
+    if (node) {
+        if (node == 'select') {
+            var bcategory = node.options[node.selectedIndex].value;
+            var bcategoryRequired = node.parentNode.getElementsByTagName('span').length;
+        } else {
+            var bcategory = node.value;
+            var bcategoryRequired = false;
+        }
     } else {
-        var bcategory = node.value;
+        var bcategory = null;
         var bcategoryRequired = false;
     }
 

--- a/Products/PloneBooking/skins/plonebooking_templates/booking_filter.pt
+++ b/Products/PloneBooking/skins/plonebooking_templates/booking_filter.pt
@@ -1,9 +1,10 @@
-<tal:block
-   define="btool nocall:here/portal_booking;
-	   btype request/btype | btype | nothing;
+<metal:block define-macro="main"
+   i18n:domain="plonebooking"
+   tal:define="btool nocall:here/portal_booking;
+           btype request/btype | btype | nothing;
            bcategory request/bcategory | bcategory | nothing;
            bookableobject request/bookableobject | bookableobject | nothing;
-	   default_mode python:here.getDefaultViewMode();
+           default_mode python:here.getDefaultViewMode();
            dmode dmode | python:request.get('dmode', default_mode);
            default_view python:here.getDefaultCalendarView();
            dview dview | python:request.get('dview', default_view);
@@ -26,8 +27,6 @@
            charset here/getCharset;
            dummy python:request.RESPONSE.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, private, must-revalidate, pre-check=0, post-check=0');
            dummy python:request.RESPONSE.setHeader('Content-Type', 'text/html;;charset=%s' % charset);">
-  <metal:block define-macro="main"
-               i18n:domain="plonebooking">
     <fieldset id="fieldset-filter" class="opened">
       <legend i18n:translate="label_filter_form">Filter</legend>
 
@@ -181,5 +180,4 @@
 	     i18n:attributes="value OK" />
     </div>
 
-  </metal:block>
-</tal:block>
+</metal:block>


### PR DESCRIPTION
Empty values in POST caused bad catalog searches with empty results ;
On JS side, while refreshing the filter on Booking Center with no category, canRefresh was failing silenciously (JS error, no refresh) ;
Finally, booking_filter.pt was oddly constructed.
