### PR TITLE
Use portal_catalog instead of uid_catalog to avoid Unauthorized getObject

### DIFF
--- a/Products/PloneBooking/skins/plonebooking_scripts/plonebooking_add.py
+++ b/Products/PloneBooking/skins/plonebooking_scripts/plonebooking_add.py
@@ -20,7 +20,7 @@ response = request.RESPONSE
 atool = getToolByName(context, 'archetype_tool')
 btool = getToolByName(context, 'portal_booking')
 ftool = getToolByName(context, 'portal_factory')
-utool = getToolByName(context, 'uid_catalog')
+ctool = getToolByName(context, 'portal_catalog')
 
 type_name = 'Booking'
 
@@ -34,7 +34,7 @@ else:
     if hasattr(atool, 'getObject'):
         bookable_obj = atool.getObject(obj_uid)
     else:
-        bookable_obj = utool(UID=obj_uid)[0].getObject()
+        bookable_obj = ctool.searchResults({'UID': obj_uid})[0].getObject()
 booking_id = context.generateUniqueId(type_name)
 start_date = end_date = None
 date_format = '%Y/%m/%d %H:%M:%S'


### PR DESCRIPTION
The plonebooking_add script raised the following error when you are coming from the plonebooking_add_form

```
Module script, line 23, in plonebooking_add
    <FSPythonScript at /plonebooking_add used for />
    Line 23
Unauthorized: You are not allowed to access 'getObject' in this context
```

The reference_catalog and uid_catalog getObject methods are no more callable in Python (Script) and Page Templates in recent Plone versions.

We can use instead the portal_catalog to get the object.
